### PR TITLE
more clear error message

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -314,7 +314,7 @@ sub assert_lib {
     unlink $cfile;
 
     my $miss_string = join( q{, }, map { qq{'$_'} } @missing );
-    die("Can't link/include $miss_string\n") if @missing;
+    die("Can't link/include C library $miss_string, aborting.\n") if @missing;
     my $wrong_string = join( q{, }, map { qq{'$_'} } @wrongresult);
     die("wrong result: $wrong_string\n") if @wrongresult;
 }

--- a/t/exit_with_message.t
+++ b/t/exit_with_message.t
@@ -18,7 +18,7 @@ if($err =~ /Couldn't find your C compiler/) {
     plan skip_all => "Couldn't find your C compiler";
 } else {
     plan tests => 1;
-    like ($err, "/^Can't link\\/include 'hlagh'/ms", 
+    like ($err, "/^Can't link\\/include C library 'hlagh'/ms",
         "missing hlagh detected non-fatally"
     );
 }

--- a/t/not_found.t
+++ b/t/not_found.t
@@ -36,7 +36,7 @@ for my $c ( @cases ) {
     my $err = $@;
     ok ( $err, "died on '$c->{arg}'" );
     my $miss_string = join(q{, }, map { qq{'$_'} } @{$c->{missing}} );
-    like ($err, "/^Can't link\/include ${miss_string}/ms", 
+    like ($err, "/^Can't link\/include C library ${miss_string}/ms",
         "missing $miss_string detected"
     );
     ok(!check_lib(debug => $debug, eval($c->{arg})),


### PR DESCRIPTION
When encountering a message about a missing library in Makefile output, it can be very unclear what's happening:

https://gist.github.com/09065609fcd0847ce96d

This commit changes the message to explain a bit better what it's about.
