### PR TITLE
Handle the case for no exe extension for Cygwin

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -377,6 +377,10 @@ sub _findcc {
         my $compiler = File::Spec->catfile($path, $cc[0]) . $Config{_exe};
         return ([ $compiler, @cc[1 .. $#cc], @ccflags ], \@ldflags)
             if -x $compiler;
+        next if ! length $Config{_exe};
+        $compiler = File::Spec->catfile($path, $cc[0]);
+        return ([ $compiler, @cc[1 .. $#cc], @ccflags ], \@ldflags)
+            if -x $compiler;
     }
     die("Couldn't find your C compiler\n");
 }


### PR DESCRIPTION
On, at least,  Cygwin perl-5.14.2-3, `$Config{cc}` is `'gcc-4'` and `$Config{_exe}` is `'.exe'`. On the other hand, there is no `gcc-4.exe`. `/usr/bin/gcc-4` is a symlink to `/usr/bin/gcc.exe`. So, most tests are skipped by `Couldn't find your C compiler` like http://www.cpantesters.org/cpan/report/4090954b-71a6-1014-9a36-9dd55cf4dae8

To fix it, I added check for the case of no extension even if `$Config{_exe}` is defined.
