### PR TITLE
fix crashes on some systems, caused by combining libs kernel32 and msvcrt

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -365,7 +365,7 @@ sub _findcc {
     # Need to use $keep=1 to work with MSWin32 backslashes and quotes
     my $Config_ccflags =  $Config{ccflags};  # use copy so ASPerl will compile
     my @Config_ldflags = ();
-    for my $config_val ( @Config{qw(ldflags perllibs)} ){
+    for my $config_val ( @Config{qw(ldflags)} ){
         push @Config_ldflags, $config_val if ( $config_val =~ /\S/ );
     }
     my @ccflags = grep { length } quotewords('\s+', 1, $Config_ccflags||'');


### PR DESCRIPTION
This fixes #6 by partly reverting a commit @tonycoz contributed in #4:
"correctly pass linker options to MSVC"
74a1a8b6aad91340629f228a5faa313157a0a4c5

Notably on ActivePerl, using the ActiveState-provided MinGW the changes introduced by that commit cause the programs compiled during testing to be linked to both kernel32 and msvcrt, which causes them to crash when being executed.

This commit fixes that by taking perllibs config variable out of the list of options to be passed to the linker. This may cause some warnings on systems that use MSVC instead of MinGW, but is highly preferred to crashes and test failures.