### PR TITLE
update .travis.yml, add 5.18 and 5.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: perl
 perl:
+  - 5.20
+  - 5.18
   - 5.16
   - 5.14


### PR DESCRIPTION
Travis appears to support Perl 5.20 now. Added 5.18 and 5.20. 