### PR TITLE
Perl's VC Makefile has -nodefaultlib in LINK_FLAGS

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -310,7 +310,8 @@ sub assert_lib {
                 "/Fe$exefile",
                 (map { '/I'.Win32::GetShortPathName($_) } @incpaths),
 		"/link",
-		@$ld
+		@$ld,
+		split(' ', $Config{libs}),
             );
         } elsif($Config{cc} =~ /bcc32(\.exe)?/) {    # Borland
             @sys_cmd = (
@@ -362,6 +363,7 @@ sub assert_lib {
                 (map { '/I'.Win32::GetShortPathName($_) } @incpaths),
                 "/link",
                 @$ld,
+                split(' ', $Config{libs}),
                 (map {'/libpath:'.Win32::GetShortPathName($_)} @libpaths),
             );
         } elsif($Config{cc} eq 'CC/DECC') {          # VMS


### PR DESCRIPTION
This means `$Config{ldflags}` also ends up including that. Therefore, `assert_lib` fails to build executables. E.g. see this [test report][1].

This patch fixes the test failures, as well as failures in normal use to verify existence of correctly installed libraries, by adding the libraries specified in `$Config{libs}`.

I am not sure if this is the best way to handle the situation, but it seems to work.

[1]: http://www.cpantesters.org/cpan/report/6b5e2c37-6c63-1014-a1df-a81897e06df3