### PR TITLE
Test analyze_binary

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -21,3 +21,4 @@ t/cmdline-LIBS-INC.t
 t/custom-function.t
 META.yml                                 Module meta-data (added by MakeMaker)
 t/analyze-binary.t
+t/flags.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -20,3 +20,4 @@ t/coverage.sh
 t/cmdline-LIBS-INC.t
 t/custom-function.t
 META.yml                                 Module meta-data (added by MakeMaker)
+t/analyze-binary.t

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -142,6 +142,14 @@ incpaths, each preceded by '-I'.
 
 This can also be supplied on the command-line.
 
+=item ccflags
+
+Extra flags to pass to the compiler.
+
+=item ldflags
+
+Extra flags to pass to the linker.
+
 =item analyze_binary
 
 a callback function that will be invoked in order to perform custom
@@ -293,7 +301,7 @@ sub assert_lib {
         }
     }
 
-    my ($cc, $ld) = _findcc($args{debug});
+    my ($cc, $ld) = _findcc($args{debug}, $args{ccflags}, $args{ldflags});
     my @missing;
     my @wrongresult;
     my @wronganalysis;
@@ -455,15 +463,15 @@ sub _cleanup_exe {
 # where $cc is an array ref of compiler name, compiler flags
 # where $ld is an array ref of linker flags
 sub _findcc {
-    my ($debug) = @_;
+    my ($debug, $user_ccflags, $user_ldflags) = @_;
     # Need to use $keep=1 to work with MSWin32 backslashes and quotes
     my $Config_ccflags =  $Config{ccflags};  # use copy so ASPerl will compile
     my @Config_ldflags = ();
     for my $config_val ( @Config{qw(ldflags)} ){
         push @Config_ldflags, $config_val if ( $config_val =~ /\S/ );
     }
-    my @ccflags = grep { length } quotewords('\s+', 1, $Config_ccflags||'');
-    my @ldflags = grep { length } quotewords('\s+', 1, @Config_ldflags);
+    my @ccflags = grep { length } quotewords('\s+', 1, $Config_ccflags||'', $user_ccflags||'');
+    my @ldflags = grep { length } quotewords('\s+', 1, @Config_ldflags, $user_ldflags||'');
     my @paths = split(/$Config{path_sep}/, $ENV{PATH});
     my @cc = split(/\s+/, $Config{cc});
     if (check_compiler ($cc[0], $debug)) {

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -54,7 +54,7 @@ and link to the libraries.
 
 It works by trying to compile some code - which defaults to this:
 
-    int main(void) { return 0; }
+    int main(int argc, char *argv[]) { return 0; }
 
 and linking it to the specified libraries.  If something pops out the end
 which looks executable, it gets executed, and if main() returns 0 we know
@@ -355,7 +355,7 @@ sub assert_lib {
     my $ofile = $cfile;
     $ofile =~ s/\.c$/$Config{_o}/;
     print $ch qq{#include <$_>\n} foreach (@headers);
-    print $ch "int main(void) { ".($args{function} || 'return 0;')." }\n";
+    print $ch "int main(int argc, char *argv[]) { ".($args{function} || 'return 0;')." }\n";
     close($ch);
     for my $lib ( @libs ) {
         my $exefile = File::Temp::mktemp( 'assertlibXXXXXXXX' ) . $Config{_exe};

--- a/t/analyze-binary.t
+++ b/t/analyze-binary.t
@@ -1,0 +1,54 @@
+use strict;
+# compatible use warnings
+BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
+
+use lib 't/lib';
+use IO::CaptureOutput qw(capture);
+use Config;
+
+use File::Spec;
+use Test::More;
+
+eval "use Devel::CheckLib";
+if($@ =~ /Couldn't find your C compiler/) {
+    plan skip_all => "Couldn't find your C compiler";
+}
+my $libdir;
+eval "use Helper qw(create_testlib)";
+unless($libdir = create_testlib("bazbam")) {
+    plan skip_all => "Couldn't build a library to test against";
+};
+
+my($debug, $stdout, $stderr) = ($ENV{DEVEL_CHECKLIB_DEBUG} || 0);
+
+sub diagout { diag "\tSTDOUT: $stdout\n\tSTDERR: $stderr\n" }
+
+sub analyze_binary {
+    my ($lib, $bin, $expected_rc, @args) = @_;
+    $bin = File::Spec->rel2abs($bin);
+    system $bin, @args;
+    warn "\$?: $?, expected: ".($expected_rc << 8)."\n";
+    return ($? == ($expected_rc << 8));
+}
+
+my %common = ( debug => $debug,
+               incpath => 't/inc',
+               libpath => $libdir,
+               lib => 'bazbam',
+               header => 'headerfile.h',
+               function => 'return (argc - 1);',
+             );
+
+capture
+    sub { eval { assert_lib(%common,
+                            analyze_binary => sub { analyze_binary @_, 3, qw(foo  bar doz) } ) } },
+    \$stdout, \$stderr;
+is($@, '', "analyze_binary ok") or diagout;
+
+capture
+    sub { eval { assert_lib(%common,
+                            analyze_binary => sub { analyze_binary @_, 3, qw(foo) } ) } },
+    \$stdout, \$stderr;
+like($@, qr/wrong analysis/i, "analyze_binary wrong") or diagout;
+
+done_testing;

--- a/t/flags.t
+++ b/t/flags.t
@@ -1,0 +1,51 @@
+use strict;
+# compatible use warnings
+BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
+
+use lib 't/lib';
+use IO::CaptureOutput qw(capture);
+use Config;
+
+use File::Spec;
+use Test::More;
+
+eval "use Devel::CheckLib";
+if($@ =~ /Couldn't find your C compiler/) {
+    plan skip_all => "Couldn't find your C compiler";
+}
+my $libdir;
+eval "use Helper qw(create_testlib)";
+unless($libdir = create_testlib("bazbam")) {
+    plan skip_all => "Couldn't build a library to test against";
+};
+
+my($debug, $stdout, $stderr) = ($ENV{DEVEL_CHECKLIB_DEBUG} || 0);
+
+sub diagout { diag "\tSTDOUT: $stdout\n\tSTDERR: $stderr\n" }
+
+my %common = ( debug => $debug,
+               incpath => 't/inc',
+               libpath => $libdir,
+               lib => 'bazbam',
+               header => 'headerfile.h',
+               function => <<EOF);
+
+#ifdef FOO1234
+return 0;
+#else
+return 1;
+#endif
+
+EOF
+
+capture
+    sub { eval { assert_lib(%common, ccflags => '-DFOO1234') } },
+    \$stdout, \$stderr;
+is($@, '', "ccflags ok") or diagout;
+
+capture
+    sub { eval { assert_lib(%common) } },
+    \$stdout, \$stderr;
+like($@, qr/wrong/i, "ccflags wrong") or diagout;
+
+done_testing;


### PR DESCRIPTION
In order to perform the tests in a portable and simple way, I have also added support for passing arguments to the `main` function, just replacing the `int main(void)` signature by `int main(int argc, char *argv[])`.

This may actually be an interesting feature in itself as it would allow to extract extra information from the library as its version, optional features, etc. from analyze_binary. Even if it is probably outside of the original scope of the module, in practice it may be quite handy.