### PR TITLE
Fix order of flags for gcc

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -343,9 +343,9 @@ sub assert_lib {
         } else { # Unix-ish: gcc, Sun, AIX (gcc, cc), ...
             @sys_cmd = (
                 @$cc,
-                @$ld,
-                $cfile,
                 (map { "-I$_" } @incpaths),
+                $cfile,
+                @$ld,
                 "-o", "$exefile"
             );
         }
@@ -399,12 +399,12 @@ sub assert_lib {
                                                      # gcc, Sun, AIX (gcc, cc)
             @sys_cmd = (
                 @$cc,
-                @$ld,
-                $cfile,
-                "-o", "$exefile",
                 (map { "-I$_" } @incpaths),
+                $cfile,
                 (map { "-L$_" } @libpaths),
                 "-l$lib",
+                @$ld,
+                "-o", "$exefile",
             );
         }
         warn "# @sys_cmd\n" if $args{debug};


### PR DESCRIPTION
In gcc order of libraries, object files and source code files is important.
If file A uses symbols from file B, then A must be specified prior to B.

If parameters are in incorrect order then gcc can throw fatal error
"undefined reference to...".

This patch fixes this problem. First is source file being compiled, next is
library specified for linking and after that are ld flags which may contain
additional libraries on which either source file or library specified for
linking depends.