### PR TITLE
Improve Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,12 +31,20 @@ WriteMakefile1(
     )],
 );
 
-sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.21. Added by eumm-upgrade.
+sub WriteMakefile1 {  #Compatibility code for old versions of EU::MM. Written by Alexandr Ciornii, version 2. Added by eumm-upgrade.
     my %params=@_;
     my $eumm_version=$ExtUtils::MakeMaker::VERSION;
     $eumm_version=eval $eumm_version;
     die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
     die "License not specified" if not exists $params{LICENSE};
+    if ($params{AUTHOR} and ref($params{AUTHOR}) eq 'ARRAY' and $eumm_version < 6.5705) {
+        $params{META_ADD}->{author}=$params{AUTHOR};
+        $params{AUTHOR}=join(', ',@{$params{AUTHOR}});
+    }
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.64) {
+        $params{BUILD_REQUIRES}={ %{$params{BUILD_REQUIRES} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
     if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
         #EUMM 6.5502 has problems with BUILD_REQUIRES
         $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,13 @@ $^W = 1;
 
 WriteMakefile1(
     NAME         => 'Devel::CheckLib',
+    ABSTRACT_FROM => 'lib/Devel/CheckLib.pm',
     VERSION_FROM => 'lib/Devel/CheckLib.pm',
+    AUTHOR => [
+        'David Cantrell',
+        'David Golden',
+        'Yasuhiro Matsumoto',
+    ],
     PREREQ_PM    => {
         'File::Temp'        => 0.16,
         'Exporter'          => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ WriteMakefile1(
     },
     MIN_PERL_VERSION => '5.00405',
     META_MERGE => {
+        dynamic_config => 0,
         resources => {
             repository => 'http://github.com/mattn/p5-Devel-CheckLib',
         },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile1(
             repository => 'http://github.com/mattn/p5-Devel-CheckLib',
         },
     },
-    BUILD_REQUIRES => {
+    TEST_REQUIRES => {
         'Test::More'        => 0.62,  # too high? but API changed here
         'IO::CaptureOutput' => 1.0801,
         'Mock::Config'      => 0.02,


### PR DESCRIPTION
This PR improves Makefile.PL.
Especially added ABSTRACT_FROM and AUTHOR to Makefile.PL;
this generates META.json/META.yaml which have proper "abstract" and "author" fields.
https://metacpan.org/source/MATTN/Devel-CheckLib-1.12/META.json#L2-5