### PR TITLE
Use Capture::Tiny instead of IO::CaptureOutput

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,9 +28,9 @@ WriteMakefile1(
         },
     },
     TEST_REQUIRES => {
-        'Test::More'        => 0.88,  # done_testing
-        'IO::CaptureOutput' => 1.0801,
-        'Mock::Config'      => 0.02,
+        'Test::More'    => 0.88,  # done_testing
+        'Capture::Tiny' => 0,
+        'Mock::Config'  => 0.02,
     },
     LICENSE => 'perl',
     EXE_FILES    => [qw(

--- a/t/analyze-binary.t
+++ b/t/analyze-binary.t
@@ -3,7 +3,7 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Config;
 
 use File::Spec;
@@ -39,16 +39,19 @@ my %common = ( debug => $debug,
                function => 'return (argc - 1);',
              );
 
-capture
-    sub { eval { assert_lib(%common,
-                            analyze_binary => sub { analyze_binary @_, 3, qw(foo  bar doz) } ) } },
-    \$stdout, \$stderr;
-is($@, '', "analyze_binary ok") or diagout;
+my $error;
+($stdout, $stderr) = capture {
+    eval { assert_lib(%common,
+                            analyze_binary => sub { analyze_binary @_, 3, qw(foo  bar doz) } ) };
+    $error = $@;
+};
+is($error, '', "analyze_binary ok") or diagout;
 
-capture
-    sub { eval { assert_lib(%common,
-                            analyze_binary => sub { analyze_binary @_, 3, qw(foo) } ) } },
-    \$stdout, \$stderr;
-like($@, qr/wrong analysis/i, "analyze_binary wrong") or diagout;
+($stdout, $stderr) = capture {
+    eval { assert_lib(%common,
+                            analyze_binary => sub { analyze_binary @_, 3, qw(foo) } ) };
+    $error = $@;
+};
+like($error, qr/wrong analysis/i, "analyze_binary wrong") or diagout;
 
 done_testing;

--- a/t/cmdline-LIBS-INC.t
+++ b/t/cmdline-LIBS-INC.t
@@ -3,7 +3,7 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Config;
 
 use File::Spec;
@@ -36,48 +36,42 @@ my $runtime = '-l'.(
 
 my $rval = undef;
 my @args = (qq{LIBS=$runtime});
-capture(
-    sub { $rval = system(
+($stdout, $stderr) = capture {
+    $rval = system(
         $Config{perlpath},
 	'-Mblib',
 	'-MDevel::CheckLib',
 	'-e',
 	"print @ARGV;assert_lib(debug => $debug)",
         @args
-    )},
-    \$stdout,
-    \$stderr
-);
+    );
+};
 ok($stderr eq '' && defined($rval) && $rval == 0, "linked OK: ".join(', ', @args)) || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
 
 $rval = undef;
 @args = map { "LIBS=$_" } ($runtime, '-lbazbam', "-L$libdir");
-capture(
-    sub { $rval = system(
+($stdout, $stderr) = capture {
+    $rval = system(
         $Config{perlpath},
 	'-Mblib',
 	'-MDevel::CheckLib',
 	'-e',
 	"print @ARGV;assert_lib(debug => $debug)",
         @args
-    )},
-    \$stdout,
-    \$stderr
-);
+    );
+};
 ok($stderr eq '' && defined($rval) && $rval == 0, "linked OK: ".join(', ', @args)) || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
 
 $rval = undef;
 @args = (qq{"LIBS=$runtime -lbazbam -L$libdir"});
-capture(
-    sub { $rval = system(
+($stdout, $stderr) = capture {
+    $rval = system(
         $Config{perlpath},
 	'-Mblib',
 	'-MDevel::CheckLib',
 	'-e',
 	"print @ARGV;assert_lib(debug => $debug)",
         @args
-    )},
-    \$stdout,
-    \$stderr
-);
+    );
+};
 ok($stderr eq '' && defined($rval) && $rval == 0, "linked OK: ".join(', ', @args)) || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");

--- a/t/dash-l-libs.t
+++ b/t/dash-l-libs.t
@@ -3,13 +3,13 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Config;
 
 use File::Spec;
 use Test::More;
 
-my($debug, $stdout, $stderr) = ($ENV{DEVEL_CHECKLIB_DEBUG} || 0);
+my $debug = $ENV{DEVEL_CHECKLIB_DEBUG} || 0;
 my $libdir;
 
 eval "use Devel::CheckLib";
@@ -37,9 +37,9 @@ my $runtime = '-l'.(
 # my $runtime = $^O eq 'MSWin32' ? '-lmsvcrt' : '-lm';
 my $args = qq{LIBS => '$runtime -lbazbam -L$libdir'};
 
-capture(
-    sub { eval "assert_lib(debug => $debug, $args)"; },
-    \$stdout,
-    \$stderr
-);
-is($@, q{}, "$args") || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
+my $error;
+my ($stdout, $stderr) = capture {
+    eval "assert_lib(debug => $debug, $args)";
+    $error = $@;
+};
+is($error, q{}, "$args") || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");

--- a/t/flags.t
+++ b/t/flags.t
@@ -3,7 +3,7 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Config;
 
 use File::Spec;
@@ -38,14 +38,17 @@ return 1;
 
 EOF
 
-capture
-    sub { eval { assert_lib(%common, ccflags => '-DFOO1234') } },
-    \$stdout, \$stderr;
-is($@, '', "ccflags ok") or diagout;
+my $error;
+($stdout, $stderr) = capture {
+    eval { assert_lib(%common, ccflags => '-DFOO1234') };
+    $error = $@;
+};
+is($error, '', "ccflags ok") or diagout;
 
-capture
-    sub { eval { assert_lib(%common) } },
-    \$stdout, \$stderr;
-like($@, qr/wrong/i, "ccflags wrong") or diagout;
+($stdout, $stderr) = capture {
+    eval { assert_lib(%common) };
+    $error = $@;
+};
+like($error, qr/wrong/i, "ccflags wrong") or diagout;
 
 done_testing;

--- a/t/headers.t
+++ b/t/headers.t
@@ -3,7 +3,7 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Config;
 
 use File::Spec;
@@ -14,7 +14,7 @@ if($@ =~ /Couldn't find your C compiler/) {
     plan skip_all => "Couldn't find your C compiler";
 }
 
-my($debug, $stdout, $stderr) = ($ENV{DEVEL_CHECKLIB_DEBUG} || 0);
+my $debug = $ENV{DEVEL_CHECKLIB_DEBUG} || 0;
 
 # cases are strings to interpolate into the assert_lib call
 my %failcases = (
@@ -30,19 +30,19 @@ my @passcases = (
 plan tests => scalar(keys %failcases) + scalar(@passcases);
 
 for my $c (keys %failcases) {
-    capture(
-        sub { eval "assert_lib(debug => $debug, $c)"; },
-        \$stdout,
-        \$stderr
-    );
-    ok($@ =~ /^$failcases{$c}/, "$c") ||
+    my $error;
+    my ($stdout, $stderr) = capture {
+        eval "assert_lib(debug => $debug, $c)";
+        $error = $@;
+    };
+    ok($error =~ /^$failcases{$c}/, "$c") ||
         diag("$@\n\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
 }
 for my $c ( @passcases ) {
-    capture(
-        sub { eval "assert_lib(debug => $debug, $c)"; },
-        \$stdout,
-        \$stderr
-    );
-    is($@, q{}, "$c") || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
+    my $error;
+    my ($stdout, $stderr) = capture {
+        eval "assert_lib(debug => $debug, $c)";
+        $error = $@;
+    };
+    is($error, q{}, "$c") || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
 }

--- a/t/perl_mm_opt.t
+++ b/t/perl_mm_opt.t
@@ -3,7 +3,7 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Config;
 
 use File::Spec;
@@ -36,28 +36,24 @@ my $runtime = '-l'.(
 local $ENV{PERL_MM_OPT} = "LIBS='$runtime'";
 
 my $rval = undef;
-capture(
-    sub { $rval = system(
+($stdout, $stderr) = capture {
+    $rval = system(
         $Config{perlpath},
 	'-Mblib',
 	'-MDevel::CheckLib',
 	'-e',
-	"print @ARGV;assert_lib(debug => $debug)")},
-    \$stdout,
-    \$stderr
-);
+	"print @ARGV;assert_lib(debug => $debug)");
+};
 ok($stderr eq '' && defined($rval) && $rval == 0, "linked OK: ".$ENV{PERL_MM_OPT}) || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
 
 $rval = undef;
 local $ENV{PERL_MM_OPT} = "LIBS='$runtime -lbazbam -L$libdir'";
-capture(
-    sub { $rval = system(
+($stdout, $stderr) = capture {
+    $rval = system(
         $Config{perlpath},
 	'-Mblib',
 	'-MDevel::CheckLib',
 	'-e',
-	"print @ARGV;assert_lib(debug => $debug)")},
-    \$stdout,
-    \$stderr
-);
+	"print @ARGV;assert_lib(debug => $debug)");
+};
 ok($stderr eq '' && defined($rval) && $rval == 0, "linked OK: ".$ENV{PERL_MM_OPT}) || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");

--- a/t/unpath.t
+++ b/t/unpath.t
@@ -2,10 +2,10 @@ use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 
 use lib 't/lib';
-use IO::CaptureOutput qw(capture);
+use Capture::Tiny qw(capture);
 use Test::More;
 
-my($debug, $stdout, $stderr) = ($ENV{DEVEL_CHECKLIB_DEBUG} || 0);
+my $debug = $ENV{DEVEL_CHECKLIB_DEBUG} || 0;
 
 eval "use Devel::CheckLib";
 if($@ =~ /Couldn't find your C compiler/) { #'
@@ -19,15 +19,15 @@ my $incpath = "$path/include";
 my $libpath = "$path/lib";
 my @rpath = ($set_rpath ? (ldflags => "-Wl,-rpath=$libpath") : ());
 
-capture sub { eval {
+my ($stdout, $stderr) = capture { eval {
     assert_lib(debug => $debug,
            header => 'libssh2.h',
            lib => 'ssh2',
            incpath => $incpath,
            libpath => $libpath,
            @rpath,
-           function => 'libssh2_init(0); return 0;') }},
-    \$stdout, \$stderr;
+           function => 'libssh2_init(0); return 0;') }
+};
 ok($stderr eq '' || $stderr !~ /^No such file or directory/, "linked OK") || diag("\tSTDOUT: $stdout\n\tSTDERR: $stderr\n");
 
 done_testing;


### PR DESCRIPTION
IO::CaptureOutput has been discouraged since 1.1103 (released in 2015) and marked as deprecated with 1.1105.

This patch modified the test suite so it uses Capture::Tiny instead.