### PR TITLE
Fix for dirs with space in

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+refactor, stop GCC optimising away test code
+
 1.14    2019-11-12      Use Capture::Tiny instead of Capture::Output
 
 1.13    2018-06-23      Improve Makefile.PL

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -327,12 +327,11 @@ sub assert_lib {
         my @sys_cmd;
         # FIXME: re-factor - almost identical code later when linking
         if ( $Config{cc} eq 'cl' ) {                 # Microsoft compiler
-            require Win32;
             @sys_cmd = (
                 @$cc,
                 $cfile,
                 "/Fe$exefile",
-                (map { '/I'.Win32::GetShortPathName($_) } @incpaths),
+                (map { '/I'.$_ } @incpaths),
 		"/link",
 		@$ld,
 		_parsewords($Config{libs}),
@@ -374,9 +373,8 @@ sub assert_lib {
         my $exefile = File::Temp::mktemp( 'assertlibXXXXXXXX' ) . $Config{_exe};
         my @sys_cmd;
         if ( $Config{cc} eq 'cl' ) {                 # Microsoft compiler
-            require Win32;
             my @libpath = map { 
-                q{/libpath:} . Win32::GetShortPathName($_)
+                q{/libpath:} . $_
             } @libpaths; 
             # this is horribly sensitive to the order of arguments
             @sys_cmd = (
@@ -384,11 +382,11 @@ sub assert_lib {
                 $cfile,
                 "${lib}.lib",
                 "/Fe$exefile", 
-                (map { '/I'.Win32::GetShortPathName($_) } @incpaths),
+                (map { '/I'.$_ } @incpaths),
                 "/link",
                 @$ld,
 		_parsewords($Config{libs}),
-                (map {'/libpath:'.Win32::GetShortPathName($_)} @libpaths),
+                (map {'/libpath:'.$_} @libpaths),
             );
         } elsif($Config{cc} eq 'CC/DECC') {          # VMS
         } elsif($Config{cc} =~ /bcc32(\.exe)?/) {    # Borland

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -448,6 +448,7 @@ sub _findcc {
     my ($debug, $user_ccflags, $user_ldflags) = @_;
     # Need to use $keep=1 to work with MSWin32 backslashes and quotes
     my $Config_ccflags =  $Config{ccflags};  # use copy so ASPerl will compile
+    $Config_ccflags =~ s:-O\S*::; # stop GCC optimising away test code
     my @Config_ldflags = ();
     for my $config_val ( @Config{qw(ldflags)} ){
         push @Config_ldflags, $config_val if ( $config_val =~ /\S/ );

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -268,17 +268,12 @@ sub _parsewords {
 
 sub assert_lib {
     my %args = @_;
-    my (@libs, @libpaths, @headers, @incpaths);
-
-    # FIXME: these four just SCREAM "refactor" at me
-    @libs = (ref($args{lib}) ? @{$args{lib}} : $args{lib}) 
-        if $args{lib};
-    @libpaths = (ref($args{libpath}) ? @{$args{libpath}} : $args{libpath}) 
-        if $args{libpath};
-    @headers = (ref($args{header}) ? @{$args{header}} : $args{header}) 
-        if $args{header};
-    @incpaths = (ref($args{incpath}) ? @{$args{incpath}} : $args{incpath}) 
-        if $args{incpath};
+    $args{$_} = [$args{$_}]
+        for grep $args{$_} && !ref($args{$_}), qw(lib libpath header incpath);
+    my @libs = @{$args{lib} || []};
+    my @libpaths = @{$args{libpath} || []};
+    my @headers = @{$args{header} || []};
+    my @incpaths = @{$args{incpath} || []};
     my $analyze_binary = $args{analyze_binary};
     my $not_execute = $args{not_execute};
 

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -460,10 +460,8 @@ sub _cleanup_exe {
         $pdbfile =~ s/$Config{_exe}$/.pdb/;
 	push @rmfiles, $ilkfile, $pdbfile;
     }
-    foreach (@rmfiles) {
-	if ( -f $_ ) {
-	    unlink $_ or warn "Could not remove $_: $!";
-	}
+    foreach (grep -f, @rmfiles) {
+	unlink $_ or warn "Could not remove $_: $!";
     }
     return
 }

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -370,6 +370,7 @@ sub assert_lib {
     print $ch "int main(int argc, char *argv[]) { ".($args{function} || 'return 0;')." }\n";
     close($ch);
     for my $lib ( @libs ) {
+        last if $Config{cc} eq 'CC/DECC';          # VMS
         my $exefile = File::Temp::mktemp( 'assertlibXXXXXXXX' ) . $Config{_exe};
         my @sys_cmd;
         if ( $Config{cc} eq 'cl' ) {                 # Microsoft compiler
@@ -388,7 +389,6 @@ sub assert_lib {
 		_parsewords($Config{libs}),
                 (map {'/libpath:'.$_} @libpaths),
             );
-        } elsif($Config{cc} eq 'CC/DECC') {          # VMS
         } elsif($Config{cc} =~ /bcc32(\.exe)?/) {    # Borland
             @sys_cmd = (
                 @$cc,

--- a/t/exit_with_message.t
+++ b/t/exit_with_message.t
@@ -12,7 +12,7 @@ check_lib_or_exit( qw/lib hlagh/ );
 ENDPRINT
 $fh->close;
 
-my $err = `$^X $fh 2>&1`;
+my $err = `"$^X" $fh 2>&1`;
 
 if($err =~ /Couldn't find your C compiler/) {
     plan skip_all => "Couldn't find your C compiler";

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -62,20 +62,19 @@ sub _gcc_lib {
     my $ar = find_binary('ar') or return;
     my $ranlib = find_binary('ranlib') or return;
     my $ccflags = $Config{ccflags};
-
-    _quiet_system("$cc $ccflags -c ${libname}.c") and return;
-    _quiet_system("$ar rc lib${libname}.a ${libname}.o") and return;
-    _quiet_system("$ranlib lib${libname}.a") and return;
-    return -f "lib${libname}.a"
+    my $libfile = "lib${libname}.a";
+    _quiet_system(qq{"$cc" $ccflags -c ${libname}.c}) and return;
+    _quiet_system($ar, 'rc', $libfile, "${libname}$Config{_o}") and return;
+    _quiet_system($ranlib, $libfile) and return;
+    return -f $libfile
 }
 
 sub _cl_lib {
     my ($libname) = @_;
     my $cc = find_compiler() or return;
     my $ar = find_binary('lib') or return;
-
     _quiet_system($cc, '/c',  "${libname}.c") and return;
-    _quiet_system($ar, "${libname}.obj") and return;
+    _quiet_system($ar, "${libname}$Config{_o}") and return;
     return -f "${libname}.lib";
 }
 

--- a/t/multi-word-compiler.t
+++ b/t/multi-word-compiler.t
@@ -20,19 +20,20 @@ BEGIN {
     }
 }
 
+my $fake_cc = qq{"$^X" $Config{cc}};
 if ($Mock::Config::VERSION) {
-    Mock::Config->import(cc => "$^X $Config{cc}");
+    Mock::Config->import(cc => $fake_cc);
 }
 elsif (defined($ActivePerl::VERSION) && $Config{cc} =~ /\bgcc\b/) {
     my $obj = tied %Config::Config;
-    $obj->{cc} = "$^X $Config{cc}";
+    $obj->{cc} = $fake_cc;
 }
 else {
-    eval { $Config{cc} = "$^X $Config{cc}"; }
+    eval { $Config{cc} = $fake_cc; }
 }
 
 SKIP: {
     skip "Couldn't update %Config", 1 if $@ =~ /%Config::Config is read-only/;
     eval "use Devel::CheckLib";
-    ok(!$@, "Good multi-word compiler is OK");
+    is $@, "", "Good multi-word compiler is OK";
 }


### PR DESCRIPTION
The tests fail when the Perl executable path has a space in it. This fixes that.