### PR TITLE
Use rpath when compiling on macOS.

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -402,23 +402,19 @@ sub assert_lib {
                 $cfile);
         } else {                                     # Unix-ish
                                                      # gcc, Sun, AIX (gcc, cc)
-            my @rpath;
-            if ($^O eq "darwin") {
-                @rpath = map { "-Wl,-rpath,$_" } @libpaths;
-            }
             @sys_cmd = (
                 @$cc,
                 (map { "-I$_" } @incpaths),
                 $cfile,
                 (map { "-L$_" } @libpaths),
-                @rpath,
+                ($^O eq 'darwin' ? (map { "-Wl,-rpath,$_" } @libpaths) : ()),
                 "-l$lib",
                 @$ld,
                 "-o", "$exefile",
             );
         }
         warn "# @sys_cmd\n" if $args{debug};
-        local $ENV{LD_RUN_PATH} = join(":", grep $_, @libpaths, $ENV{LD_RUN_PATH}) unless $^O eq 'MSWin32';
+        local $ENV{LD_RUN_PATH} = join(":", grep $_, @libpaths, $ENV{LD_RUN_PATH}) unless $^O eq 'MSWin32' or $^O eq 'darwin';
         local $ENV{PATH} = join(";", @libpaths).";".$ENV{PATH} if $^O eq 'MSWin32';
         my $rv = $args{debug} ? system(@sys_cmd) : _quiet_system(@sys_cmd);
         if ($rv != 0 || ! -f $exefile) {

--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -402,11 +402,16 @@ sub assert_lib {
                 $cfile);
         } else {                                     # Unix-ish
                                                      # gcc, Sun, AIX (gcc, cc)
+            my @rpath;
+            if ($^O eq "darwin") {
+                @rpath = map { "-Wl,-rpath,$_" } @libpaths;
+            }
             @sys_cmd = (
                 @$cc,
                 (map { "-I$_" } @incpaths),
                 $cfile,
                 (map { "-L$_" } @libpaths),
+                @rpath,
                 "-l$lib",
                 @$ld,
                 "-o", "$exefile",


### PR DESCRIPTION
This fixes [issue #337](https://github.com/perl5-dbi/DBD-mysql/issues/337) for `DBD::mysql`. When compiling on macOS the rpath must be explicitly set with linker option `-Wl,-rpath` or else the dynamic loader will refuse to load the library. Note that many workarounds exists like setting `DYLD_LIBRARY_PATH` or using `install_name_tool`. However, setting rpath for the generated executable is to be preferred and is the simplest solution.