### PR TITLE
add a "prologue" option for additional code between headers and main

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -78,6 +78,9 @@ In that case, it will fail to build if either foo() or libversion() don't
 exist, and main() will return the wrong value if libversion()'s return
 value isn't what you want.
 
+You can also use the C<prologue> parameter to add extra supporting
+code between the headers and the definition of C<main>.
+
 =head1 FUNCTIONS
 
 All of these take the same named parameters and are exported by default.
@@ -306,9 +309,10 @@ sub _compile_cmd {
 }
 
 sub _make_cfile {
-    my ($use_headers, $function, $debug) = @_;
+    my ($use_headers, $function, $debug, $prologue) = @_;
     my $code = '';
     $code .= qq{#include <$_>\n} for @$use_headers;
+    $code .= "$prologue\n" if defined $prologue;
     $code .= "int main(int argc, char *argv[]) { ".($function || 'return 0;')." }\n";
     if ($debug) {
 	(my $c = $code) =~ s:^:# :gm;
@@ -383,7 +387,7 @@ sub assert_lib {
     }
 
     # now do each library in turn with headers
-    my ($cfile, $ofile) = _make_cfile(\@use_headers, @args{qw(function debug)});
+    my ($cfile, $ofile) = _make_cfile(\@use_headers, @args{qw(function debug prologue)});
     for my $lib ( @libs ) {
         last if $Config{cc} eq 'CC/DECC';          # VMS
         my $exefile = File::Temp::mktemp( 'assertlibXXXXXXXX' ) . $Config{_exe};

--- a/t/custom-function.t
+++ b/t/custom-function.t
@@ -62,6 +62,14 @@ my %passcases = (
         header => 'headerfile.h',
         functionbody => 'foo();if(libversion() > 5) return 0; else return 1;'
     }, "function exists and other function returns right value",
+    qq{
+        incpath => 't/inc',
+        libpath => '$libdir',
+        lib => 'bazbam',
+        header => 'headerfile.h',
+        functionbody => 'bar(); return 0;',
+        prologue => 'void bar() { foo(); }'
+    }, "test prologue",
 );
 
 plan tests => scalar(keys %failcases) + scalar(keys %passcases);


### PR DESCRIPTION
I use this in Imager::Font::FT2 due to Freetype 2.x's supported way of handling headers, where you include a support header and then include other headers by macro:

  #include <ft2build.h>
  #include FT_FREETYPE_H
  #include FT_MULTIPLE_MASTERS_H
  #include FT_TYPE1_TABLES_H

This could be useful for other global definitions that might be used to test a library, such as callback function definitions.