### PR TITLE
clean up assertlib*.dSYM/ directories produced by clang on darwin

### DIFF
--- a/lib/Devel/CheckLib.pm
+++ b/lib/Devel/CheckLib.pm
@@ -11,6 +11,7 @@ use Text::ParseWords qw(quotewords shellwords);
 
 use File::Spec;
 use File::Temp;
+use File::Path qw(rmtree);
 
 require Exporter;
 @ISA = qw(Exporter);
@@ -437,6 +438,12 @@ sub _cleanup_exe {
     }
     foreach (grep -f, @rmfiles) {
 	unlink $_ or warn "Could not remove $_: $!";
+    }
+    if ($^O eq "darwin") {
+      # created by clang on darwin
+      my $dsym_dir = $exefile;
+      $dsym_dir =~ s/\Q$Config{_exe}\E$/.dSYM/;
+      rmtree $dsym_dir if -d $dsym_dir;
     }
     return
 }


### PR DESCRIPTION
After a perl Makefile.PL/make test I see something like:

 tony@hermes p5-Devel-CheckLib % git status
 On branch darwin-cleanup
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
         assertlib0uydTE9v.dSYM/
         assertlib1CTMeFWc.dSYM/
         assertlib2uBL9Oyl.dSYM/
         assertlib3tD91c3I.dSYM/
         assertlib5ME0r5Di.dSYM/
         ...